### PR TITLE
Query DSL 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    querydsl.extendsFrom compileClasspath
 }
 
 repositories {
@@ -36,11 +37,28 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+clean {
+    delete file(querydslDir)
 }
 
 dependencyManagement {

--- a/src/main/java/com/insert/ioj/domain/contest/service/ProblemContestService.java
+++ b/src/main/java/com/insert/ioj/domain/contest/service/ProblemContestService.java
@@ -3,7 +3,7 @@ package com.insert.ioj.domain.contest.service;
 import com.insert.ioj.domain.contest.domain.Contest;
 import com.insert.ioj.domain.contest.facade.ContestFacade;
 import com.insert.ioj.domain.contest.presentation.dto.res.ListContestProblemResponse;
-import com.insert.ioj.domain.problemContest.domain.repository.ProblemContestRepository;
+import com.insert.ioj.domain.problemContest.domain.repository.CustomCompetitionContestRepository;
 import com.insert.ioj.domain.user.domain.User;
 import com.insert.ioj.domain.user.facade.UserFacade;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +16,12 @@ import java.util.List;
 public class ProblemContestService {
     private final UserFacade userFacade;
     private final ContestFacade contestFacade;
-    private final ProblemContestRepository problemContestRepository;
+    private final CustomCompetitionContestRepository customProblemContestRepository;
 
     public List<ListContestProblemResponse> execute(Long contestId) {
         User user = userFacade.getCurrentUser();
         Contest contest = contestFacade.getContest(contestId);
         contest.checkRole(user.getAuthority());
-        return problemContestRepository.getContestProblemsWithStatus(contest, user);
+        return customProblemContestRepository.getContestProblemsWithStatus(contest, user);
     }
 }

--- a/src/main/java/com/insert/ioj/domain/problemContest/domain/repository/CustomCompetitionContestRepository.java
+++ b/src/main/java/com/insert/ioj/domain/problemContest/domain/repository/CustomCompetitionContestRepository.java
@@ -1,0 +1,11 @@
+package com.insert.ioj.domain.problemContest.domain.repository;
+
+import com.insert.ioj.domain.contest.domain.Contest;
+import com.insert.ioj.domain.contest.presentation.dto.res.ListContestProblemResponse;
+import com.insert.ioj.domain.user.domain.User;
+
+import java.util.List;
+
+public interface CustomCompetitionContestRepository {
+    List<ListContestProblemResponse> getContestProblemsWithStatus(Contest contest, User user);
+}

--- a/src/main/java/com/insert/ioj/domain/problemContest/domain/repository/ProblemContestRepository.java
+++ b/src/main/java/com/insert/ioj/domain/problemContest/domain/repository/ProblemContestRepository.java
@@ -1,10 +1,8 @@
 package com.insert.ioj.domain.problemContest.domain.repository;
 
 import com.insert.ioj.domain.contest.domain.Contest;
-import com.insert.ioj.domain.contest.presentation.dto.res.ListContestProblemResponse;
 import com.insert.ioj.domain.problem.domain.Problem;
 import com.insert.ioj.domain.problemContest.domain.ProblemContest;
-import com.insert.ioj.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,16 +14,4 @@ public interface ProblemContestRepository extends JpaRepository<ProblemContest, 
 
     @Query("SELECT problem FROM ProblemContest WHERE contest = :contest")
     List<Problem> getProblems(@Param("contest") Contest contest);
-
-    @Query("SELECT new com.insert.ioj.domain.contest.presentation.dto.res.ListContestProblemResponse(p.id, p.level, p.title, " +
-        "CASE " +
-        "WHEN sc.isPass = true THEN 'solved' " +
-        "WHEN sc.isPass = false THEN 'failed' " +
-        "ELSE 'unsolved' " +
-        "END) " +
-        "FROM ProblemContest pc " +
-        "JOIN pc.problem p " +
-        "LEFT JOIN SolveContest sc ON pc = sc.problemContest AND sc.user = :user " +
-        "WHERE pc.contest = :contest")
-    List<ListContestProblemResponse> getContestProblemsWithStatus(@Param("contest") Contest contest, @Param("user") User user);
 }

--- a/src/main/java/com/insert/ioj/domain/problemContest/infra/CustomProblemContestRepositoryImpl.java
+++ b/src/main/java/com/insert/ioj/domain/problemContest/infra/CustomProblemContestRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.insert.ioj.domain.problemContest.infra;
+
+import com.insert.ioj.domain.contest.domain.Contest;
+import com.insert.ioj.domain.contest.presentation.dto.res.ListContestProblemResponse;
+import com.insert.ioj.domain.problemContest.domain.repository.CustomCompetitionContestRepository;
+import com.insert.ioj.domain.user.domain.User;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.insert.ioj.domain.problem.domain.QProblem.problem;
+import static com.insert.ioj.domain.problemContest.domain.QProblemContest.problemContest;
+import static com.insert.ioj.domain.solveContest.domain.QSolveContest.solveContest;
+import static com.querydsl.core.types.Projections.constructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomProblemContestRepositoryImpl implements CustomCompetitionContestRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ListContestProblemResponse> getContestProblemsWithStatus(Contest contest, User user) {
+        return jpaQueryFactory
+            .select(constructor(ListContestProblemResponse.class,
+                problem.id, problem.level, problem.title,
+                new CaseBuilder()
+                    .when(solveContest.isPass.isTrue()).then("solved")
+                    .when(solveContest.isPass.isFalse()).then("failed")
+                    .otherwise("unsolved")))
+            .from(problemContest)
+            .join(problemContest.problem, problem)
+            .leftJoin(solveContest).on(problemContest.eq(solveContest.problemContest)
+                .and(solveContest.user.eq(user)))
+            .where(problemContest.contest.eq(contest))
+            .fetch();
+    }
+}

--- a/src/main/java/com/insert/ioj/global/config/QueryDslConfig.java
+++ b/src/main/java/com/insert/ioj/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.insert.ioj.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class QueryDslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
## 💡 개요
querydsl을 도입 후 JPQL을 사용한 부분을 리팩터링 하였습니다.
## 📃 작업내용
- querydsl을 도입하였습니다.
- getContestProblemsWithStatus를 JPQL에서 querydsl로 변경하였습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타