### PR TITLE
nickname 저장 오류 해결

### DIFF
--- a/src/main/java/com/insert/ioj/domain/auth/service/GoogleAuthLinkService.java
+++ b/src/main/java/com/insert/ioj/domain/auth/service/GoogleAuthLinkService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class GoogleAuthLinkService {
     private static final String QUERY_STRING = "?client_id=%s&redirect_uri=%s" +
-            "&response_type=token&scope=https://www.googleapis.com/auth/userinfo.email";
+            "&response_type=token&scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
     private final AuthProperties authProperties;
 
     public String execute() {


### PR DESCRIPTION
## 💡 개요
nickname이 null로 저장되는 버그가 있어 수정하였습니다.
## 📃 작업내용
- auth link에서 닉네임을 넘겨주는 부분이 삭제되어 있어 추가하였습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타