### PR TITLE
학교 유저 일반 대회 참가 안 됨

### DIFF
--- a/src/main/java/com/insert/ioj/domain/contest/domain/Contest.java
+++ b/src/main/java/com/insert/ioj/domain/contest/domain/Contest.java
@@ -34,7 +34,7 @@ public class Contest {
     }
 
     public void checkRole(Authority authority) {
-        if (this.authority == null) return;
+        if (authority == Authority.USER) return;
         if (this.authority == authority) return;
         if (this.authority == Authority.ADMIN) return;
 


### PR DESCRIPTION
## 💡 개요
학교 유저가 일반유저 권한의 대회가 참여되지 않는 경우가 있어 수정하였습니다.
## 📃 작업내용
- 학교 유저의 권한 범위를 수정하였습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타