### PR TITLE
재제출 방지 기능 추가

### DIFF
--- a/src/main/java/com/insert/ioj/domain/contest/service/SubmitContestService.java
+++ b/src/main/java/com/insert/ioj/domain/contest/service/SubmitContestService.java
@@ -13,6 +13,7 @@ import com.insert.ioj.domain.execution.service.ExecutionService;
 import com.insert.ioj.domain.problem.domain.Problem;
 import com.insert.ioj.domain.problem.domain.repository.ProblemRepository;
 import com.insert.ioj.domain.solveContest.domain.SolveContest;
+import com.insert.ioj.domain.solveContest.domain.repository.CustomSolveContestRepository;
 import com.insert.ioj.domain.solveContest.domain.repository.SolveContestRepository;
 import com.insert.ioj.domain.user.domain.User;
 import com.insert.ioj.domain.user.facade.UserFacade;
@@ -34,6 +35,7 @@ import java.util.List;
 public class SubmitContestService {
     private final TestcaseRepository testcaseRepository;
     private final SolveContestRepository solveContestRepository;
+    private final CustomSolveContestRepository customSolveContestRepository;
     private final ContestFacade contestFacade;
     private final ProblemRepository problemRepository;
     private final UserFacade userFacade;
@@ -49,6 +51,8 @@ public class SubmitContestService {
         Contest contest = contestFacade.getContest(request.getContestId());
 
         contest.checkRole(user.getAuthority());
+
+        existsCorrectProblem(contest, user, problem);
 
         Execution execution = ExecutionFactory.createExecution(
             request.getSourcecode(),
@@ -74,6 +78,12 @@ public class SubmitContestService {
         deleteEnvironment(execution);
 
         return verdict;
+    }
+
+    private void existsCorrectProblem(Contest contest, User user, Problem problem) {
+        Boolean isCorrect = customSolveContestRepository.existsByCorrectProblem(contest, user, problem);
+        if (isCorrect)
+            throw new IojException(ErrorCode.ALREADY_SOLVED_PROBLEM);
     }
 
     private TestcaseResult getTestcaseResult(Execution execution, Testcase testcase) {

--- a/src/main/java/com/insert/ioj/domain/solveContest/domain/repository/CustomSolveContestRepository.java
+++ b/src/main/java/com/insert/ioj/domain/solveContest/domain/repository/CustomSolveContestRepository.java
@@ -2,6 +2,7 @@ package com.insert.ioj.domain.solveContest.domain.repository;
 
 import com.insert.ioj.domain.contest.domain.Contest;
 import com.insert.ioj.domain.contest.presentation.dto.res.ListRankResponse;
+import com.insert.ioj.domain.problem.domain.Problem;
 import com.insert.ioj.domain.solveContest.domain.SolveContest;
 import com.insert.ioj.domain.user.domain.User;
 
@@ -10,4 +11,5 @@ import java.util.List;
 public interface CustomSolveContestRepository {
     List<SolveContest> getUserSolveContest(User user, Contest contest);
     List<ListRankResponse> getRankingUser(Contest contest);
+    Boolean existsByCorrectProblem(Contest contest, User user, Problem problem);
 }

--- a/src/main/java/com/insert/ioj/domain/solveContest/domain/repository/CustomSolveContestRepositoryImpl.java
+++ b/src/main/java/com/insert/ioj/domain/solveContest/domain/repository/CustomSolveContestRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.insert.ioj.domain.solveContest.domain.repository;
 import com.insert.ioj.domain.contest.domain.Contest;
 import com.insert.ioj.domain.contest.presentation.dto.res.ListRankResponse;
 import com.insert.ioj.domain.execution.domain.type.Verdict;
+import com.insert.ioj.domain.problem.domain.Problem;
 import com.insert.ioj.domain.solveContest.domain.SolveContest;
 import com.insert.ioj.domain.user.domain.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -43,5 +44,17 @@ public class CustomSolveContestRepositoryImpl implements CustomSolveContestRepos
             .orderBy(solveContest.verdict.count().desc(),
                 solveContest.createDate.max().asc())
             .fetch();
+    }
+
+    @Override
+    public Boolean existsByCorrectProblem(Contest contest, User user, Problem problem) {
+        Integer fetchOne = queryFactory
+            .selectOne()
+            .from(solveContest)
+            .where(solveContest.contest.eq(contest).and(solveContest.user.eq(user)
+                .and(solveContest.problem.eq(problem)
+                .and(solveContest.verdict.eq(Verdict.ACCEPTED)))))
+            .fetchOne();
+        return fetchOne != null;
     }
 }

--- a/src/main/java/com/insert/ioj/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/insert/ioj/global/error/exception/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
     INVALID_TOKEN(401, "TOKEN-401-1", "올바르지 않은 형식의 Token입니다."),
     EXPIRED_PERIOD_TOKEN(401, "TOKEN-401-2", "기한이 만료된 Token입니다."),
 
+    ALREADY_SOLVED_PROBLEM(409, "PROBLEM-409-1", "이미 해결된 문제입니다."),
+
     INTERNAL_SERVER_ERROR(500, "SERVER-500-1", "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요.");
 
     private final int status;


### PR DESCRIPTION
## 💡 개요
재제출을 하여 문제를 맞추고 나중에 순위 집계를 할 시 재제출도 문제수 집계에 포함되어 순위에 영향이 가게 되어
문제를 맞추면 이후에 재제출을 할 수 없도록 하였습니다.
## 📃 작업내용
- 재제출을 할 시 랭킹을 조회하는 로직에 문제가 생겨 재제출을 방지하는 로직을 추가하였습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타