### PR TITLE
종료된 대회 제출 금지

### DIFF
--- a/src/main/java/com/insert/ioj/domain/contest/domain/Contest.java
+++ b/src/main/java/com/insert/ioj/domain/contest/domain/Contest.java
@@ -45,4 +45,10 @@ public class Contest {
             case FIRST_YEAR -> throw new IojException(ErrorCode.FORBIDDEN_FIRST_YEAR);
         }
     }
+
+    public void isFinished() {
+        if (this.endTime.isBefore(LocalDateTime.now())) {
+            throw new IojException(ErrorCode.FINISHED_CONTEST);
+        }
+    }
 }

--- a/src/main/java/com/insert/ioj/domain/contest/service/SubmitContestService.java
+++ b/src/main/java/com/insert/ioj/domain/contest/service/SubmitContestService.java
@@ -50,6 +50,7 @@ public class SubmitContestService {
         User user = userFacade.getCurrentUser();
         Contest contest = contestFacade.getContest(request.getContestId());
 
+        contest.isFinished();
         contest.checkRole(user.getAuthority());
 
         existsCorrectProblem(contest, user, problem);

--- a/src/main/java/com/insert/ioj/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/insert/ioj/global/error/exception/ErrorCode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    FINISHED_CONTEST(400, "CONTEST-400-1", "종료된 대회입니다."),
     ALREADY_USER(400, "ROOM-400-1", "이미 유저가 방에 참가중입니다."),
     FULL_ROOM(400, "ROOM-400-2", "방에 유저가 가득 찼습니다."),
     NOT_READY_ROOM(400, "ROOM-400-3", "방에 준비를 하지 않은 유저가 있습니다."),


### PR DESCRIPTION
## 💡 개요
대회가 종료 되었을 때 제출이 더 이상 되지 않게 막아두었습니다.
## 📃 작업내용
- 종료된 대회에 한정해서는 제출이 더 이상 가능하지 않도록 변경하였습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타