### PR TITLE
fix(#158): 1,3학년 권한 부여 수정

### DIFF
--- a/src/main/java/com/insert/ioj/domain/auth/service/GoogleAuthService.java
+++ b/src/main/java/com/insert/ioj/domain/auth/service/GoogleAuthService.java
@@ -49,11 +49,11 @@ public class GoogleAuthService {
     private Authority getAuthority(String email) {
         if (email.endsWith("@bssm.hs.kr")) {
             if (email.startsWith("2022")) {
-                return Authority.FIRST_YEAR;
+                return Authority.THIRD_YEAR;
             } else if (email.startsWith("2023")) {
                 return Authority.SECOND_YEAR;
             } else if (email.startsWith("24.")) {
-                return Authority.THIRD_YEAR;
+                return Authority.FIRST_YEAR;
             } else {
                 return Authority.USER;
             }


### PR DESCRIPTION
## 💡 개요
1학년 구글 계정으로 로그인 시 권한이 3학년 권한으로 부여가 되는 오류를 수정하였습니다.
## 📃 작업내용
- 1,3학년의 권한 부여가 수정
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타