### PR TITLE
대회 권한 핸들링 수정

### DIFF
--- a/src/main/java/com/insert/ioj/domain/contest/domain/Contest.java
+++ b/src/main/java/com/insert/ioj/domain/contest/domain/Contest.java
@@ -34,7 +34,7 @@ public class Contest {
     }
 
     public void checkRole(Authority authority) {
-        if (authority == Authority.USER) return;
+        if (this.authority == Authority.USER) return;
         if (this.authority == authority) return;
         if (this.authority == Authority.ADMIN) return;
 


### PR DESCRIPTION
## 💡 개요
학년 권한을 가진 사람들은 일반 유저의 대회 권한이 없다고 에러가 생겨 수정하였습니다.
## 📃 작업내용
- 대회에 권한 로직 수정
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타