### PR TITLE
대회 시작 전 에러 반환

### DIFF
--- a/src/main/java/com/insert/ioj/domain/contest/domain/Contest.java
+++ b/src/main/java/com/insert/ioj/domain/contest/domain/Contest.java
@@ -46,6 +46,12 @@ public class Contest {
         }
     }
 
+    public void isNotStarted() {
+        if (this.startTime.isAfter(LocalDateTime.now())) {
+            throw new IojException(ErrorCode.NOT_STARTED_CONTEST);
+        }
+    }
+
     public void isFinished() {
         if (this.endTime.isBefore(LocalDateTime.now())) {
             throw new IojException(ErrorCode.FINISHED_CONTEST);

--- a/src/main/java/com/insert/ioj/domain/contest/service/GetContestService.java
+++ b/src/main/java/com/insert/ioj/domain/contest/service/GetContestService.java
@@ -24,6 +24,8 @@ public class GetContestService {
     public ContestResponse execute(Long contestId) {
         User user = userFacade.getCurrentUser();
         Contest contest = contestFacade.getContest(contestId);
+
+        contest.isNotStarted();
         contest.checkRole(user.getAuthority());
 
         List<ProblemStatusDto> problemStatuses = problemFacade.getProblemStatuses(contest, user);

--- a/src/main/java/com/insert/ioj/domain/contest/service/SubmitContestService.java
+++ b/src/main/java/com/insert/ioj/domain/contest/service/SubmitContestService.java
@@ -50,6 +50,7 @@ public class SubmitContestService {
         User user = userFacade.getCurrentUser();
         Contest contest = contestFacade.getContest(request.getContestId());
 
+        contest.isNotStarted();
         contest.isFinished();
         contest.checkRole(user.getAuthority());
 

--- a/src/main/java/com/insert/ioj/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/insert/ioj/global/error/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     FINISHED_CONTEST(400, "CONTEST-400-1", "종료된 대회입니다."),
+    NOT_STARTED_CONTEST(400, "CONTEST-400-2", "시작 전 대회입니다."),
     ALREADY_USER(400, "ROOM-400-1", "이미 유저가 방에 참가중입니다."),
     FULL_ROOM(400, "ROOM-400-2", "방에 유저가 가득 찼습니다."),
     NOT_READY_ROOM(400, "ROOM-400-3", "방에 준비를 하지 않은 유저가 있습니다."),


### PR DESCRIPTION
## 💡 개요
대회 시작 전에 조회/제출을 할 경우 에러를 반환합니다.
## 📃 작업내용
- 대회 시작 전 에러 반환 로직 작성
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타