### PR TITLE
방 상태 검증 로직 수정

### DIFF
--- a/src/main/java/com/insert/ioj/domain/room/domain/Room.java
+++ b/src/main/java/com/insert/ioj/domain/room/domain/Room.java
@@ -86,9 +86,11 @@ public class Room extends BaseTimeEntity {
     }
 
     public void isActive() {
-        switch (status) {
-            case RECRUITING -> throw new IojException(ErrorCode.NOT_STARTED_ROOM);
-            case ENDED -> throw new IojException(ErrorCode.FINISHED_ROOM);
+        if (status == RoomStatus.RECRUITING) {
+            throw new IojException(ErrorCode.NOT_STARTED_ROOM);
+        }
+        if (endTime.isBefore(LocalDateTime.now())) {
+            throw new IojException(ErrorCode.FINISHED_ROOM);
         }
     }
 

--- a/src/main/java/com/insert/ioj/domain/room/domain/type/RoomStatus.java
+++ b/src/main/java/com/insert/ioj/domain/room/domain/type/RoomStatus.java
@@ -2,6 +2,5 @@ package com.insert.ioj.domain.room.domain.type;
 
 public enum RoomStatus {
     RECRUITING,
-    STARTED,
-    ENDED
+    STARTED
 }


### PR DESCRIPTION
## 💡 개요
방 상태를 저장하는 enum에서 ended를 사용하지 않아 삭제하고 방의 시작 상태를 확인하는 함수를 수정 하였습니다.
## 📃 작업내용
- RoomStatus ENDED속성이 있었는데 필요가 없어 삭제하였습니다.
- 방의 시작 중인지 확인하는 함수로직을 수정하였습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타