### PR TITLE
방 입장 로직 수정

### DIFF
--- a/src/main/java/com/insert/ioj/domain/room/service/JoinRoomService.java
+++ b/src/main/java/com/insert/ioj/domain/room/service/JoinRoomService.java
@@ -3,6 +3,7 @@ package com.insert.ioj.domain.room.service;
 import com.insert.ioj.domain.entry.domain.Entry;
 import com.insert.ioj.domain.entry.domain.repository.EntryRepository;
 import com.insert.ioj.domain.room.domain.Room;
+import com.insert.ioj.domain.room.domain.type.RoomStatus;
 import com.insert.ioj.domain.room.facade.RoomFacade;
 import com.insert.ioj.domain.room.presentation.dto.res.JoinRoomResponse;
 import com.insert.ioj.domain.user.domain.User;
@@ -27,6 +28,9 @@ public class JoinRoomService {
         Room room = roomFacade.getRoom(roomId);
         User user = userFacade.getCurrentUser();
 
+        if (room.getStatus() != RoomStatus.RECRUITING) {
+            throw new IojException(ErrorCode.STARTED_OR_FINISHED_ROOM);
+        }
         room.addPeople(user);
         alreadyUser(user, room);
         entryRepository.save(new Entry(room, user));

--- a/src/main/java/com/insert/ioj/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/insert/ioj/global/error/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     STARTED_ROOM(400, "ROOM-400-4", "이미 게임을 시작한 방입니다."),
     NOT_STARTED_ROOM(400, "ROOM-400-5", "시작 전 방입니다."),
     FINISHED_ROOM(400, "ROOM-400-6", "종료된 방입니다."),
+    STARTED_OR_FINISHED_ROOM(400, "ROOM-400-7", "게임이 시작되었거나 종료되었습니다."),
     NOT_READY_HOST(400, "HOST-400-1", "호스트는 준비상태 변경이 가능하지 않습니다."),
     NOT_LEAVE_HOST(400, "HOST-400-2", "호스트는 방에서 떠날 수 없습니다."),
 


### PR DESCRIPTION
## 💡 개요
게임이 시작 혹은 종료가 되었어도 입장이 가능하여 시작 혹은 종료가 되었을 때 입장을 하면 에러를 반환하는 로직을 작성하였습니다.
## 📃 작업내용
- 게임이 시작 혹은 종료되었을 때 입장이 불가하다는 에러를 반환합니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타