### PR TITLE
방 시작시 예외 핸들링

### DIFF
--- a/src/main/java/com/insert/ioj/domain/entry/domain/repository/EntryRepository.java
+++ b/src/main/java/com/insert/ioj/domain/entry/domain/repository/EntryRepository.java
@@ -16,5 +16,5 @@ public interface EntryRepository extends JpaRepository<Entry, Long> {
     Boolean existsByUserAndRoom(User user, Room room);
 
     @Query("SELECT COUNT(*) FROM Entry WHERE room = :room and ready = true")
-    Optional<Long> countIsReady(@Param("room") Room room);
+    Long countIsReady(@Param("room") Room room);
 }

--- a/src/main/java/com/insert/ioj/domain/room/service/StartGameService.java
+++ b/src/main/java/com/insert/ioj/domain/room/service/StartGameService.java
@@ -60,9 +60,10 @@ public class StartGameService {
     }
 
     private void checkReadyUser(Room room) {
-        Long cntIsReady = entryRepository.countIsReady(room)
-            .orElseThrow(() -> new IojException(ErrorCode.NOT_FOUND_ROOM_IN_USER));
-        if (room.getMaxPeople()-1 == cntIsReady) {
+        if (room.getPeopleCnt() == 1) {
+            throw new IojException(ErrorCode.NOT_FOUND_ROOM_IN_USER);
+        }
+        if (room.getPeopleCnt() == entryRepository.countIsReady(room)) {
             throw new IojException(ErrorCode.NOT_READY_ROOM);
         }
     }


### PR DESCRIPTION
## 💡 개요
게임을 시작할 때 에러를 반환할 때 호스트만 entry에 있어도 게임이 시작되어 호스트 이외에 한 명 더 있어야 게임이 시작되도록 변경하였습니다.
## 📃 작업내용
- 방을 시작할 때 예외를 처리하기 위한 조건이 이상하여 if문 조건을 수정하였습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타