### PR TITLE
아이템 사용이 되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/insert/ioj/domain/item/domain/repository/CustomUserItemRepository.java
+++ b/src/main/java/com/insert/ioj/domain/item/domain/repository/CustomUserItemRepository.java
@@ -8,6 +8,6 @@ import com.insert.ioj.domain.user.domain.User;
 import java.util.Optional;
 
 public interface CustomUserItemRepository {
-    Optional<UserItem> findNotUseUserItem(User user, Item item);
+    Optional<UserItem> findNotUseUserItem(Room room, User user, Item item);
     Optional<UserItem> findAttackUserItem(Item item, User user, User targetUser, Room room);
 }

--- a/src/main/java/com/insert/ioj/domain/item/domain/repository/CustomUserItemRepositoryImpl.java
+++ b/src/main/java/com/insert/ioj/domain/item/domain/repository/CustomUserItemRepositoryImpl.java
@@ -18,13 +18,14 @@ public class CustomUserItemRepositoryImpl implements CustomUserItemRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<UserItem> findNotUseUserItem(User user, Item item) {
+    public Optional<UserItem> findNotUseUserItem(Room room, User user, Item item) {
         return Optional.ofNullable(
             queryFactory
                 .selectFrom(userItem)
-                .where(userItem.user.eq(user)
+                .where(userItem.room.eq(room)
+                    .and(userItem.user.eq(user)
                     .and(userItem.item.eq(item))
-                    .and(userItem.used.isFalse()))
+                    .and(userItem.used.isFalse())))
                 .fetchFirst());
     }
 
@@ -38,6 +39,7 @@ public class CustomUserItemRepositoryImpl implements CustomUserItemRepository {
                     .and(userItem.targetUser.eq(targetUser))
                     .and(userItem.room.eq(room))
                     .and(userItem.blocked.isFalse()))
+                .orderBy(userItem.usedAt.desc())
                 .fetchFirst());
     }
 }

--- a/src/main/java/com/insert/ioj/domain/item/service/AttackUserService.java
+++ b/src/main/java/com/insert/ioj/domain/item/service/AttackUserService.java
@@ -35,7 +35,7 @@ public class AttackUserService {
 
         Long attackUserId = entryRepository.findByRoomAndUser(room, user)
             .orElseThrow(() -> new IojException(ErrorCode.NOT_FOUND_ROOM_IN_USER)).getId();
-        UserItem userItem = userItemRepository.findNotUseUserItem(user, request.getAttackItem())
+        UserItem userItem = userItemRepository.findNotUseUserItem(room, user, request.getAttackItem())
             .orElseThrow(() -> new IojException(ErrorCode.NOT_HAVE_ITEM));
 
         userItem.attack(targetUser.getUser());

--- a/src/main/java/com/insert/ioj/domain/item/service/ProtectService.java
+++ b/src/main/java/com/insert/ioj/domain/item/service/ProtectService.java
@@ -29,7 +29,7 @@ public class ProtectService {
         User attackUser = entryRepository.findById(request.getAttackUser())
             .orElseThrow(() -> new IojException(ErrorCode.NOT_FOUND_ROOM_IN_TARGET)).getUser();
 
-        userItemRepository.findNotUseUserItem(user, Item.SHIELD)
+        userItemRepository.findNotUseUserItem(room, user, Item.SHIELD)
             .orElseThrow(() -> new IojException(ErrorCode.NOT_HAVE_ITEM))
             .useShield();
 


### PR DESCRIPTION
## 💡 개요
원래 아이템을 사용했을 때 roomId를 포함하지 않고 검색을 하여서 이전 방에서 받은 아이템이 사용되었지만 현재 roomId를 포함하여 방 검색을 하여 아이템과 방어가 잘 되도록 하였습니다.
## 📃 작업내용
- 아이템 사용이 잘 되도록 변경
- 방어가 잘 되도록 수정
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타