### PR TITLE
방 시작시 준비한 유저 연산 수정

### DIFF
--- a/src/main/java/com/insert/ioj/domain/room/service/StartGameService.java
+++ b/src/main/java/com/insert/ioj/domain/room/service/StartGameService.java
@@ -63,7 +63,7 @@ public class StartGameService {
         if (room.getPeopleCnt() == 1) {
             throw new IojException(ErrorCode.NOT_FOUND_ROOM_IN_USER);
         }
-        if (room.getPeopleCnt() == entryRepository.countIsReady(room)) {
+        if (room.getPeopleCnt() != entryRepository.countIsReady(room)) {
             throw new IojException(ErrorCode.NOT_READY_ROOM);
         }
     }


### PR DESCRIPTION
## 💡 개요
방을 시작하였을 때 비교연산을 사용해서 준비한 유저와 들어온 유저를 비교하여 시작을 하였는데 일치할 시 시작을 해야하지만 비교연산자를 잘 못 사용하여서 일치하면 에러를 보내는 버그를 수정하였습니다.
## 📃 작업내용
- 게임을 시작 했을 떄 수행하는 비교 연산자 수정
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타