### PR TITLE
공격 시작 api 추가

### DIFF
--- a/src/main/java/com/insert/ioj/domain/item/domain/UserItem.java
+++ b/src/main/java/com/insert/ioj/domain/item/domain/UserItem.java
@@ -56,7 +56,6 @@ public class UserItem extends BaseTimeEntity {
 
     public void attack(User targetUser) {
         used = true;
-        usedAt = LocalDateTime.now();
         this.targetUser = targetUser;
     }
 
@@ -71,5 +70,9 @@ public class UserItem extends BaseTimeEntity {
         }
         blocked = true;
         return true;
+    }
+
+    public void attackStart() {
+        usedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/insert/ioj/domain/item/presentation/ItemController.java
+++ b/src/main/java/com/insert/ioj/domain/item/presentation/ItemController.java
@@ -3,6 +3,7 @@ package com.insert.ioj.domain.item.presentation;
 import com.insert.ioj.domain.item.presentation.dto.req.ProtectRequest;
 import com.insert.ioj.domain.item.presentation.dto.res.ListAttackUsersResponse;
 import com.insert.ioj.domain.item.presentation.dto.res.ListItemResponse;
+import com.insert.ioj.domain.item.service.AttackStartService;
 import com.insert.ioj.domain.item.service.ListAttackUsersService;
 import com.insert.ioj.domain.item.service.ListItemService;
 import com.insert.ioj.domain.item.service.ProtectService;
@@ -27,6 +28,7 @@ import java.util.UUID;
 public class ItemController {
     private final ListItemService listItemService;
     private final ListAttackUsersService listAttackUsersService;
+    private final AttackStartService attackStartService;
     private final ProtectService protectService;
 
     @Operation(summary = "가지고있는 아이템 리스트 반환")
@@ -39,6 +41,12 @@ public class ItemController {
     @GetMapping("/users/{roomId}")
     public List<ListAttackUsersResponse> listAttackUsers(@PathVariable UUID roomId) {
         return listAttackUsersService.execute(roomId);
+    }
+
+    @Operation(summary = "아이템 공격 시작")
+    @GetMapping("/attack/start/{attackItemId}")
+    public void attackStart(@PathVariable Long attackItemId) {
+        attackStartService.execute(attackItemId);
     }
 
     @Operation(summary = "공격받은 아이템 방어")

--- a/src/main/java/com/insert/ioj/domain/item/service/AttackStartService.java
+++ b/src/main/java/com/insert/ioj/domain/item/service/AttackStartService.java
@@ -1,0 +1,23 @@
+package com.insert.ioj.domain.item.service;
+
+import com.insert.ioj.domain.item.domain.UserItem;
+import com.insert.ioj.domain.item.domain.repository.UserItemRepository;
+import com.insert.ioj.global.error.exception.ErrorCode;
+import com.insert.ioj.global.error.exception.IojException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class AttackStartService {
+    private final UserItemRepository userItemRepository;
+
+    @Transactional
+    public void execute(Long attackItemId) {
+        UserItem userItem = userItemRepository.findById(attackItemId)
+            .orElseThrow(() -> new IojException(ErrorCode.NOT_FOUND_ITEM));
+
+        userItem.attackStart();
+    }
+}


### PR DESCRIPTION
## 💡 개요
- 프론트에서 Queue에 공격을 넣어 두었다가 차례가 되면 공격 시작 api를 호출해 방어 아이템을 바로 사용 가능하도록 변경하였습니다
## 📃 작업내용
- 공격 시작 api 추가
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타